### PR TITLE
Transpiration flux hydro check fix

### DIFF
--- a/components/clm/src/main/clmfates_interfaceMod.F90
+++ b/components/clm/src/main/clmfates_interfaceMod.F90
@@ -1451,7 +1451,9 @@ contains
 
         ! set transpiration input boundary condition to zero. The exposed
         ! vegetation filter may not even call every patch.
-        this%fates(nc)%bc_in(s)%qflx_transp_pa(:) = 0._r8
+        if (use_fates_planthydro) then
+           this%fates(nc)%bc_in(s)%qflx_transp_pa(:) = 0._r8
+        end if
         
      end do
   end subroutine prep_canopyfluxes


### PR DESCRIPTION
Since the fates hydro variable `qflx_transp_pa` was added to `prep_canopyfluxes` routine, the call to zero that variable needs to include a logic check to see if fates hydro is being used.  Otherwise this will result in a segfault due to not having memory allocated.

Per our discussion, I looked at the current fates_next_api branch on ctsm, and `prep_canopyfluxes` there does not include this zero'ing of the `qflx_transp_pa` variable.