### PR TITLE
Pass moisture and temp scalars from ColumnDataType to FATES

### DIFF
--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -744,6 +744,11 @@ contains
 
          nlevsoil = this%fates(nc)%bc_in(s)%nlevsoil
 
+         ! Decomposition fluxes
+         this%fates(nc)%bc_in(s)%w_scalar_sisl(1:nlevsoil) = col_cf%w_scalar(c,1:nlevsoil)
+         this%fates(nc)%bc_in(s)%t_scalar_sisl(1:nlevsoil) = col_cf%t_scalar(c,1:nlevsoil)
+
+         ! Soil water
          this%fates(nc)%bc_in(s)%h2o_liqvol_sl(1:nlevsoil)  = &
                col_ws%h2osoi_vol(c,1:nlevsoil) 
 


### PR DESCRIPTION
This implements the necessary elm-side update to enable the use of the HLM temperature and moisture variables update found in [FATES PR 705](https://github.com/NGEET/fates/pull/705).  The equivalent ctsm pr is here: https://github.com/ESCOMP/CTSM/pull/1180